### PR TITLE
require python>=3.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ authors = [
 description = 'Bouncy DVD-like terminal'
 readme = 'README.md'
 license = { file = 'LICENSE' }
-requires-python = '>=3.7'
+requires-python = '>=3.8'
 dependencies = [
 	'argcomplete>=3.6.2'
 ]


### PR DESCRIPTION
argcomplete>=3.6.2 requires python>=3.8
from `uv run hyprdvd -s`:
```  
× No solution found when resolving dependencies for split (markers: python_full_version == '3.7.*'):
  ╰─▶ Because the requested Python version (>=3.7) does not satisfy Python>=3.8 and argcomplete>=3.6.2
      depends on Python>=3.8, we can conclude that argcomplete>=3.6.2 cannot be used.
      And because only the following versions of argcomplete are available:
          argcomplete<=3.6.2
          argcomplete==3.6.3
      and your project depends on argcomplete>=3.6.2, we can conclude that your project's requirements
      are unsatisfiable.
```