### PR TITLE
ignore utf-8 errors

### DIFF
--- a/src/hyprdvd/utils.py
+++ b/src/hyprdvd/utils.py
@@ -6,5 +6,5 @@ def hyprctl(cmd):
 		['hyprctl'] + cmd, 
 		capture_output = True,
 		text = True,
-		errors = "ignore",
+		errors = 'ignore',
 	)


### PR DESCRIPTION
Fix crashing when there are windows with non-unicode characters